### PR TITLE
Fix redirects

### DIFF
--- a/templates/httpd/ssl-mailmanweb.conf.j2
+++ b/templates/httpd/ssl-mailmanweb.conf.j2
@@ -28,6 +28,8 @@ ProxyRequests off
 # Not redirecting/proxying static content (served locally)
 ProxyPass /static !
 ProxyPass /pipermail !
+ProxyPass /favicon.ico !
+ProxyPass /robots.txt !
 
 # Proxying to gunicorn mailmanweb backend
 ProxyPass / http://127.0.0.1:8000/


### PR DESCRIPTION
The favicon.ico and robots.txt shouldn't be passed to gunicorn directly and should be processed hy httpd server first.